### PR TITLE
Avoid warning about uninitialized menu

### DIFF
--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -552,7 +552,7 @@ void DecompilerContextMenu::updateTargetMenuActions()
     RCoreLocked core = Core()->core();
     if (isReference()) {
         QString name;
-        QMenu *menu;
+        QMenu *menu = NULL;
         if (annotationHere->type == R_CODE_ANNOTATION_TYPE_GLOBAL_VARIABLE
                 || annotationHere->type == R_CODE_ANNOTATION_TYPE_CONSTANT_VARIABLE) {
             menu = mainWindow->createShowInMenu(this, annotationHere->reference.offset,


### PR DESCRIPTION
Avoid warning message about potentially uninitialized variable "menu".
It is initialized in if/else so just nulling it on the beginning should do the trick.

[ 36%] Building CXX object CMakeFiles/r2cutter.dir/widgets/DisassemblyWidget.cpp.o
/usr/lib64/ccache/g++ -DCUTTER_ENABLE_GRAPHVIZ -DCUTTER_ENABLE_KSYNTAXHIGHLIGHTING -DCUTTER_SOURCE_BUILD -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -Dr2cutter_EXPORTS -IBUILD/r2cutter-0.1.1/x86_64-redhat-linux-gnu -IBUILD/r2cutter-0.1.1/src -IBUILD/r2cutter-0.1.1/x86_64-redhat-linux-gnu/r2cutter_autogen/include -IBUILD/r2cutter-0.1.1/src/core -IBUILD/r2cutter-0.1.1/src/widgets -IBUILD/r2cutter-0.1.1/src/common -IBUILD/r2cutter-0.1.1/src/plugins -IBUILD/r2cutter-0.1.1/src/menus -IBUILD/r2cutter-0.1.1/src/. -isystem /usr/include/graphviz -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtCore -isystem /usr/lib64/qt5/mkspecs/linux-g++ -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtSvg -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/libr -isystem /usr/include/libr/sdb -isystem /usr/include/capstone -isystem /usr/include/KF5/KSyntaxHighlighting -isystem /usr/include/KF5 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fvisibility=hidden   -Wall -Wextra -fPIC -std=gnu++11 -o CMakeFiles/r2cutter.dir/widgets/DisassemblyWidget.cpp.o -c BUILD/r2cutter-0.1.1/src/widgets/DisassemblyWidget.cpp
BUILD/r2cutter-0.1.1/src/menus/DecompilerContextMenu.cpp: In member function 'DecompilerContextMenu::updateTargetMenuActions()':
BUILD/r2cutter-0.1.1/src/menus/DecompilerContextMenu.cpp:575:24: warning: 'menu' may be used uninitialized in this function [-Wmaybe-uninitialized]
  575 |         action->setMenu(menu);
      |         ~~~~~~~~~~~~~~~^~~~~~

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
